### PR TITLE
fix(doc): missing space for subtitle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For exemple:
 -a eu-west-3,us-east-2
 ```
 
-####Resources Selector
+#### Resources Selector
 When pleco is running you have to specify which resources expiration will be checked.
 
 Here are some the resources you can check:


### PR DESCRIPTION
Hello @Qovery :)

Just found (due to the v2 Beta email) your very interesting repo and read the doc to get a good grasp of how this is used / work and so on.

Thank's for opensourcing this tool and here is my small doc contrib (a typo in a subtitle) :)

