### PR TITLE
Add support for enable-all flag for AWS

### DIFF
--- a/pkg/actions.go
+++ b/pkg/actions.go
@@ -105,6 +105,7 @@ func startAWS(cmd *cobra.Command, interval int64, dryRun bool, disableTTLCheck b
 		EnableSFN:            getCmdBool(cmd, "enable-sfn"),
 		EnableCloudFormation: getCmdBool(cmd, "enable-cloudformation"),
 		EnableEC2Instance:    getCmdBool(cmd, "enable-ec2-instance"),
+		EnableAll:            getCmdBool(cmd, "enable-all"),
 	}
 	aws.RunPlecoAWS(cmd, regions, interval, wg, awsOptions)
 	wg.Done()

--- a/pkg/aws/run.go
+++ b/pkg/aws/run.go
@@ -47,6 +47,7 @@ type AwsOptions struct {
 	EnableSFN            bool
 	EnableCloudFormation bool
 	EnableEC2Instance    bool
+	EnableAll            bool
 }
 
 type AWSSessions struct {
@@ -89,6 +90,27 @@ func runPlecoInRegion(region string, interval int64, wg *sync.WaitGroup, options
 	logrus.Infof("Starting to check expired resources in region %s.", *currentSession.Config.Region)
 
 	var listServiceToCheckStatus []funcDeleteExpired
+
+	// All Resources
+	if options.EnableAll {
+		options.EnableS3 = true
+		options.EnableRDS = true
+		options.EnableDocumentDB = true
+		options.EnableElastiCache = true
+		options.EnableEKS = true
+		options.EnableELB = true
+		options.EnableEBS = true
+		options.EnableVPC = true
+		options.EnableCloudWatchLogs = true
+		options.EnableKMS = true
+		options.EnableSSH = true
+		options.EnableECR = true
+		options.EnableSQS = true
+		options.EnableLambda = true
+		options.EnableSFN = true
+		options.EnableCloudFormation = true
+		options.EnableEC2Instance = true
+	}
 
 	// S3
 	if options.EnableS3 {

--- a/pkg/common/flags.go
+++ b/pkg/common/flags.go
@@ -33,6 +33,8 @@ func initAWSFlags(startCmd *cobra.Command) {
 	startCmd.Flags().BoolP("enable-sfn", "x", false, "Enable Lambda Function watch")
 	startCmd.Flags().BoolP("enable-cloudformation", "d", false, "Enable Cloudformation watch")
 	startCmd.Flags().BoolP("enable-ec2-instance", "g", false, "Enable EC2 Instance watch")
+	startCmd.Flags().Bool("enable-all", false, "Enable for all resources")
+
 }
 
 func initScalewayFlags(startCmd *cobra.Command) {


### PR DESCRIPTION
This PR adds an `--enable-all` flag for AWS resources to enable deletion for all supported resources. I've explicitly chosen not to include a short-hand flag for it so it is more clear it is more destructive.

If merged it would partially solve the issue here: https://github.com/Qovery/pleco/issues/108

Example usage:
```bash
pleco start aws --enable-all -a us-east-1

 ____  _     _____ ____ ___  
|  _ \| |   | ____/ ___/ _ \ 
| |_) | |   |  _|| |  | | | |
|  __/| |___| |__| |__| |_| |
|_|   |_____|_____\____\___/
By Qovery
INFO[2022-10-26T10:45:40-05:00] Starting Pleco 0.13.17                       
INFO[2022-10-26T10:45:40-05:00] Dry run mode enabled                         
INFO[2022-10-26T10:45:40-05:00] TTL check enabled                            
INFO[2022-10-26T10:45:40-05:00] Cloud provider: AWS                          
INFO[2022-10-26T10:45:40-05:00] Starting to check expired resources in region us-east-1. 
INFO[2022-10-26T10:45:40-05:00] Starting to check global expired resources.  
INFO[2022-10-26T10:45:41-05:00] There is no expired S3 bucket to delete in us-east-1. 
INFO[2022-10-26T10:45:41-05:00] There is no expired RDS database to delete in region us-east-1. 
INFO[2022-10-26T10:45:42-05:00] There is no expired RDS subnet group to delete in region us-east-1. 
INFO[2022-10-26T10:45:42-05:00] There is no expired RDS Parameter Group to delete in region us-east-1. 
INFO[2022-10-26T10:45:42-05:00] There is no expired RDS snapshot to delete in region us-east-1. 
INFO[2022-10-26T10:45:42-05:00] There is no expired DocumentDB database to delete in region us-east-1. 
INFO[2022-10-26T10:45:42-05:00] There is no expired RDS cluster snapshot to delete in region us-east-1. 
INFO[2022-10-26T10:45:42-05:00] There is no expired Elasticache database to delete in region us-east-1. 
INFO[2022-10-26T10:45:43-05:00] There is no unliked Elasticache subnet group to delete in region us-east-1. 
INFO[2022-10-26T10:45:43-05:00] There is no expired EKS cluster to delete in region us-east-1. 
INFO[2022-10-26T10:45:43-05:00] There is no expired ELB load balancer to delete in region us-east-1. 
INFO[2022-10-26T10:45:43-05:00] There is no expired EBS volume to delete in region us-east-1. 
```
